### PR TITLE
[Opener market - step 2] Dr-KoKo 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'jacoco'
     id 'checkstyle'
-    id 'org.springframework.boot' version '3.1.4'
+    id 'org.springframework.boot' version '3.3.4'
     id 'io.spring.dependency-management' version '1.1.3'
     id "org.sonarqube" version "4.4.1.3373"
 }

--- a/src/main/java/org/c4marathon/assignment/customer/application/ChargePointService.java
+++ b/src/main/java/org/c4marathon/assignment/customer/application/ChargePointService.java
@@ -1,0 +1,16 @@
+package org.c4marathon.assignment.customer.application;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ChargePointService {
+	public String startPayment(Command cmd) {
+		throw new UnsupportedOperationException("Not supported yet.");
+	}
+
+	public record Command(
+		Integer amount,
+		String paymentGateway
+	) {
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/customer/ui/ChargePointRequest.java
+++ b/src/main/java/org/c4marathon/assignment/customer/ui/ChargePointRequest.java
@@ -1,0 +1,7 @@
+package org.c4marathon.assignment.customer.ui;
+
+public record ChargePointRequest(
+	Integer amount,
+	String paymentGateway
+) {
+}

--- a/src/main/java/org/c4marathon/assignment/customer/ui/CustomerApi.java
+++ b/src/main/java/org/c4marathon/assignment/customer/ui/CustomerApi.java
@@ -2,6 +2,7 @@ package org.c4marathon.assignment.customer.ui;
 
 import org.c4marathon.assignment.common.api.ApiResponse;
 import org.c4marathon.assignment.customer.ui.dto.request.SignUpRequest;
+import org.c4marathon.assignment.customer.ui.dto.response.ChargePointResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,6 +25,15 @@ import org.springframework.web.bind.annotation.RequestBody;
  * @see org.c4marathon.assignment.customer.domain.Customer
  */
 public interface CustomerApi {
+	/**
+	 * 회원가입
+	 */
 	@PostMapping("/customers")
 	ResponseEntity<ApiResponse<Void>> postSignUp(@RequestBody SignUpRequest request);
+
+	/**
+	 * 포인트 충전
+	 */
+	@PostMapping("/customers/my/charge-point")
+	ResponseEntity<ApiResponse<ChargePointResponse>> postChargePoint(@RequestBody ChargePointRequest request);
 }

--- a/src/main/java/org/c4marathon/assignment/customer/ui/CustomerController.java
+++ b/src/main/java/org/c4marathon/assignment/customer/ui/CustomerController.java
@@ -4,17 +4,21 @@ import java.net.URI;
 import java.util.UUID;
 
 import org.c4marathon.assignment.common.api.ApiResponse;
+import org.c4marathon.assignment.customer.application.ChargePointService;
 import org.c4marathon.assignment.customer.application.SignUpService;
 import org.c4marathon.assignment.customer.ui.dto.request.SignUpRequest;
+import org.c4marathon.assignment.customer.ui.dto.response.ChargePointResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class CustomerController implements CustomerApi {
 	private final SignUpService signUpService;
+	private final ChargePointService chargePointService;
 
-	public CustomerController(SignUpService signUpService) {
+	public CustomerController(SignUpService signUpService, ChargePointService chargePointService) {
 		this.signUpService = signUpService;
+		this.chargePointService = chargePointService;
 	}
 
 	@Override
@@ -22,5 +26,14 @@ public class CustomerController implements CustomerApi {
 		SignUpService.Command command = new SignUpService.Command(request.email(), request.password(), request.name());
 		UUID id = signUpService.register(command);
 		return ResponseEntity.created(URI.create("/customers/" + id)).build();
+	}
+
+	@Override
+	public ResponseEntity<ApiResponse<ChargePointResponse>> postChargePoint(ChargePointRequest request) {
+		ChargePointService.Command command = new ChargePointService.Command(request.amount(), request.paymentGateway());
+		String checkoutPage = chargePointService.startPayment(command);
+		return ResponseEntity.ok(
+			new ApiResponse<>(200, "success", new ChargePointResponse(checkoutPage))
+		);
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/customer/ui/dto/response/ChargePointResponse.java
+++ b/src/main/java/org/c4marathon/assignment/customer/ui/dto/response/ChargePointResponse.java
@@ -1,0 +1,6 @@
+package org.c4marathon.assignment.customer.ui.dto.response;
+
+public record ChargePointResponse(
+	String checkoutPage
+) {
+}

--- a/src/main/java/org/c4marathon/assignment/global/config/payclient/PayClientConfig.java
+++ b/src/main/java/org/c4marathon/assignment/global/config/payclient/PayClientConfig.java
@@ -1,0 +1,58 @@
+package org.c4marathon.assignment.global.config.payclient;
+
+import org.c4marathon.assignment.payment.client.kakao.KakaoPayClient;
+import org.c4marathon.assignment.payment.client.naver.NaverPayClient;
+import org.c4marathon.assignment.payment.client.toss.TossPaymentClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+@Configuration
+public class PayClientConfig {
+	private final PayClientProperty payClientProperty;
+
+	public PayClientConfig(PayClientProperty payClientProperty) {
+		this.payClientProperty = payClientProperty;
+	}
+
+	@Bean
+	public NaverPayClient naverPayClient(RestClient.Builder clientBuilder) {
+		PayClientProperty.NaverPayClientProperty properties = payClientProperty.getNaver();
+		RestClient restClient = clientBuilder
+			.baseUrl("https://dev.apis.naver.com")
+			.defaultHeader("X-Naver-Client-Id", properties.getClientSecret())
+			.defaultHeader("X-Naver-Client-Secret", properties.getClientSecret())
+			.defaultHeader("X-NaverPay-Chain-Id", properties.getChainId())
+			.build();
+		HttpServiceProxyFactory httpServiceProxyFactory = HttpServiceProxyFactory
+			.builderFor(RestClientAdapter.create(restClient))
+			.build();
+		return httpServiceProxyFactory.createClient(NaverPayClient.class);
+	}
+
+	@Bean
+	public KakaoPayClient kakaoPayClient(RestClient.Builder clientBuilder) {
+		PayClientProperty.KakaoPayClientProperty properties = payClientProperty.getKakao();
+		RestClient restClient = clientBuilder
+			.baseUrl("https://open-api.kakaopay.com")
+			.defaultHeader("Authorization", properties.getSecretKey())
+			.build();
+		HttpServiceProxyFactory httpServiceProxyFactory = HttpServiceProxyFactory
+			.builderFor(RestClientAdapter.create(restClient))
+			.build();
+		return httpServiceProxyFactory.createClient(KakaoPayClient.class);
+	}
+
+	@Bean
+	public TossPaymentClient tossPaymentClient(RestClient.Builder clientBuilder) {
+		RestClient restClient = clientBuilder
+			.baseUrl("https://pay.toss.im")
+			.build();
+		HttpServiceProxyFactory httpServiceProxyFactory = HttpServiceProxyFactory
+			.builderFor(RestClientAdapter.create(restClient))
+			.build();
+		return httpServiceProxyFactory.createClient(TossPaymentClient.class);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/global/config/payclient/PayClientProperty.java
+++ b/src/main/java/org/c4marathon/assignment/global/config/payclient/PayClientProperty.java
@@ -1,0 +1,39 @@
+package org.c4marathon.assignment.global.config.payclient;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Configuration
+@ConfigurationProperties(prefix = "payclient")
+@Getter
+@Setter
+public class PayClientProperty {
+	private NaverPayClientProperty naver;
+	private KakaoPayClientProperty kakao;
+	private TossPayClientProperty toss;
+
+	@Getter
+	@Setter
+	public static class NaverPayClientProperty {
+		private String clientId;
+		private String clientSecret;
+		private String chainId;
+	}
+
+	@Getter
+	@Setter
+	public static class KakaoPayClientProperty {
+		private String cid;
+		private String secretKey;
+	}
+
+	@Getter
+	@Setter
+	public static class TossPayClientProperty {
+		private String clientId;
+		private String clientSecret;
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/payment/client/PaymentGatewayClient.java
+++ b/src/main/java/org/c4marathon/assignment/payment/client/PaymentGatewayClient.java
@@ -1,0 +1,11 @@
+package org.c4marathon.assignment.payment.client;
+
+public interface PaymentGatewayClient {
+	String startPayment();
+
+	String acceptPayment();
+
+	String cancelPayment();
+
+	String checkPayment();
+}

--- a/src/main/java/org/c4marathon/assignment/payment/client/kakao/KakaoPayClient.java
+++ b/src/main/java/org/c4marathon/assignment/payment/client/kakao/KakaoPayClient.java
@@ -1,0 +1,267 @@
+package org.c4marathon.assignment.payment.client.kakao;
+
+import org.c4marathon.assignment.payment.client.kakao.dto.request.StartPaymentRequest;
+import org.c4marathon.assignment.payment.client.kakao.dto.response.StartPaymentResponse;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.PostExchange;
+
+public interface KakaoPayClient {
+	/**
+	 * <h3>결제준비(ready)</h3>
+	 * <p>카카오페이 결제를 시작하기 위해 결제정보를 카카오페이 서버에 전달하고 결제 고유번호(TID)와 URL을 응답받는 단계입니다.</p>
+	 * <ol>
+	 *     <li>Secret key를 헤더에 담아 파라미터 값들과 함께 POST로 요청합니다.</li>
+	 *     <li>요청이 성공하면 응답 바디에 JSON 객체로 다음 단계 진행을 위한 값들을 받습니다.</li>
+	 *     <li>서버(Server)는 tid를 저장하고, 클라이언트는 사용자 환경에 맞는 URL로 리다이렉트(redirect)합니다.</li>
+	 * </ol>
+	 *
+	 * <h5>sample</h5>
+	 * POST /online/v1/payment/ready HTTP/1.1
+	 * Authorization: SECRET_KEY ${SECRET_KEY}
+	 * {
+	 * "cid": "TC0ONETIME",
+	 * "partner_order_id": "partner_order_id",
+	 * "partner_user_id": "partner_user_id",
+	 * "item_name": "초코파이",
+	 * "quantity": "1",
+	 * "total_amount": "2200",
+	 * "vat_amount": "200",
+	 * "tax_free_amount": "0",
+	 * "approval_url": "https://developers.kakao.com/success",
+	 * "fail_url": "https://developers.kakao.com/fail",
+	 * "cancel_url": "https://developers.kakao.com/cancel"
+	 * }
+	 *
+	 * @return
+	 * {
+	 * "tid": "T1234567890123456789",
+	 * "next_redirect_app_url": "https://mockup-pg-web.kakao.com/v1/xxxxxxxxxx/aInfo",
+	 * "next_redirect_mobile_url": "https://mockup-pg-web.kakao.com/v1/xxxxxxxxxx/mInfo",
+	 * "next_redirect_pc_url": "https://mockup-pg-web.kakao.com/v1/xxxxxxxxxx/info",
+	 * "android_app_scheme": "kakaotalk://kakaopay/pg?url=https://mockup-pg-web.kakao.com/v1/xxxxxxxxxx/order",
+	 * "ios_app_scheme": "kakaotalk://kakaopay/pg?url=https://mockup-pg-web.kakao.com/v1/xxxxxxxxxx/order",
+	 * "created_at": "2023-07-15T21:18:22"
+	 * }
+	 */
+	@PostExchange("/online/v1/payment/ready")
+	StartPaymentResponse startPayment(@RequestBody StartPaymentRequest request);
+
+	/**
+	 * <h3>결제승인(approve)</h3>
+	 * <p>사용자가 결제 수단을 선택하고 비밀번호를 입력해 결제 인증을 완료한 뒤, 최종적으로 결제 완료 처리를 하는 단계입니다.</p>
+	 * <ul>
+	 *     <li>인증완료 시 응답받은 pg_token과 tid로 최종 승인요청합니다.</li>
+	 *     <li>결제 승인 API를 호출하면 결제 준비 단계에서 시작된 결제 건이 승인으로 완료 처리됩니다.</li>
+	 *     <li>결제 승인 요청이 실패하면 카드사 등 결제 수단의 실패 정보가 필요에 따라 포함될 수 있습니다.</li>
+	 * </ul>
+	 *
+	 * <h5>sample</h5>
+	 * POST /online/v1/payment/approve HTTP/1.1
+	 * {
+	 * "cid": "TC0ONETIME",
+	 * "tid": "T1234567890123456789",
+	 * "partner_order_id": "partner_order_id",
+	 * "partner_user_id": "partner_user_id",
+	 * "pg_token": "xxxxxxxxxxxxxxxxxxxx"
+	 * }
+	 *
+	 * @return
+	 * 결제 수단 : Money
+	 * {
+	 *   "aid": "A5678901234567890123",
+	 *   "tid": "T1234567890123456789",
+	 *   "cid": "TC0ONETIME",
+	 *   "partner_order_id": "partner_order_id",
+	 *   "partner_user_id": "partner_user_id",
+	 *   "payment_method_type": "MONEY",
+	 *   "item_name": "초코파이",
+	 *   "quantity": 1,
+	 *   "amount": {
+	 *     "total": 2200,
+	 *     "tax_free": 0,
+	 *     "vat": 200,
+	 *     "point": 0,
+	 *     "discount": 0,
+	 *     "green_deposit": 0
+	 *   },
+	 *   "created_at": "2023-07-15T21:18:22",
+	 *   "approved_at": "2023-07-15T21:18:22"
+	 * }
+	 * 결제 수단 : Card
+	 * {
+	 *   "cid": "TC0ONETIME",
+	 *   "aid": "A5678901234567890123",
+	 *   "tid": "T1234567890123456789",
+	 *   "partner_user_id": "partner_user_id",
+	 *   "partner_order_id": "partner_order_id",
+	 *   "payment_method_type": "CARD",
+	 *   "item_name": "초코파이",
+	 *   "quantity": 1,
+	 *   "amount": {
+	 *     "total": 2200,
+	 *     "tax_free": 0,
+	 *     "vat": 200,
+	 *     "discount": 0,
+	 *     "point": 0,
+	 *     "green_deposit": 0
+	 *   },
+	 *   "card_info": {
+	 *     "interest_free_install": "N",
+	 *     "bin": "621640",
+	 *     "card_type": "체크",
+	 *     "card_mid": "123456789",
+	 *     "approved_id": "12345678",
+	 *     "install_month": "00",
+	 *     "installment_type": "CARD_INSTALLMENT",
+	 *     "kakaopay_purchase_corp": "비씨카드",
+	 *     "kakaopay_purchase_corp_code": "104",
+	 *     "kakaopay_issuer_corp": "수협은행",
+	 *     "kakaopay_issuer_corp_code": "212"
+	 *   },
+	 *   "created_at": "2023-07-15T21:18:22",
+	 *   "approved_at": "2023-07-15T21:18:22"
+	 * }
+	 */
+	String acceptPayment();
+
+	/**
+	 * <h3>결제 취소</h3>
+	 * <p>
+	 *     결제 고유번호인 tid에 해당하는 결제 건에 대해 지정한 금액만큼 결제 취소를 요청합니다.
+	 *     단건 결제, 정기 결제 거래건에 대해 취소가 가능합니다.
+	 *     전체 취소, 부분 취소 모두 가능하지만, 일부 특정 업종에 대해 부분 취소가 불가할 수 있습니다.
+	 *     취소 요청 시 비과세(tax_free_amount)와 부가세(vat_amount)를 맞게 요청해주셔야 합니다.
+	 * </p>
+	 *
+	 * <h5>sample</h5>
+	 * POST /online/v1/payment/cancel HTTP/1.1
+	 * Authorization: SECRET_KEY ${SECRET_KEY}
+	 * {
+	 * "cid": "TC0ONETIME",
+	 * "tid": "T1234567890123456789",
+	 * "cancel_amount": 2200,
+	 * "cancel_tax_free_amount": 0,
+	 * "cancel_vat_amount": 200,
+	 * "cancel_available_amount": 2200,
+	 * }
+	 *
+	 * @return
+	 * {
+	 *  "tid": "T1234567890123456789",
+	 *  "cid": "TC0ONETIME",
+	 *  "status": "CANCEL_PAYMENT",
+	 *  "partner_order_id": "partner_order_id",
+	 *  "partner_user_id": "partner_user_id",
+	 *  "payment_method_type": "MONEY",
+	 *  "item_name": "초코파이",
+	 *  "quantity": 1,
+	 *  "amount": {
+	 *     "total": 2200,
+	 *     "tax_free": 0,
+	 *     "vat": 200,
+	 *     "point": 0,
+	 *     "discount": 0,
+	 *     "green_deposit": 0
+	 *   },
+	 *  "amount": {
+	 *         "total": 2200,
+	 *         "tax_free": 0,
+	 *         "vat": 200,
+	 *         "point": 0,
+	 *         "discount": 0,
+	 *         "green_deposit": 0
+	 *  },
+	 *  "approved_cancel_amount": {
+	 *         "total": 2200,
+	 *         "tax_free": 0,
+	 *         "vat": 200,
+	 *         "point": 0,
+	 *         "discount": 0,
+	 *         "green_deposit": 0
+	 *  },
+	 *  "canceled_amount": {
+	 *         "total": 2200,
+	 *         "tax_free": 0,
+	 *         "vat": 200,
+	 *         "point": 0,
+	 *         "discount": 0,
+	 *         "green_deposit": 0
+	 *  },
+	 *  "cancel_available_amount": {
+	 *         "total": 0,
+	 *         "tax_free": 0,
+	 *         "vat": 0,
+	 *         "point": 0,
+	 *         "discount": 0,
+	 *         "green_deposit": 0
+	 *  },
+	 *  "created_at": "2023-07-15T21:18:22",
+	 *  "approved_at": "2023-07-15T21:18:22",
+	 *  "canceled_at": "2023-07-15T21:18:22"
+	 * }
+	 */
+	String cancelPayment();
+
+	/**
+	 * <h3>주문 조회</h3>
+	 *
+	 * <h5>sample</h5>
+	 * POST /online/v1/payment/order HTTP/1.1
+	 * Authorization: SECRET_KEY ${SECRET_KEY}
+	 * {
+	 * "cid": "TC0ONETIME",
+	 * "tid": "T1234567890123456789"
+	 * }
+	 *
+	 * @return
+	 * {
+	 *  "tid": "T1234567890123456789",
+	 *  "cid": "TC0ONETIME",
+	 *  "status": "SUCCESS_PAYMENT",
+	 *  "partner_order_id": "partner_order_id",
+	 *  "partner_user_id": "partner_user_id",
+	 *  "payment_method_type": "MONEY",
+	 *  "item_name": "초코파이",
+	 *  "quantity": 1,
+	 *  "amount": {
+	 *     "total": 2200,
+	 *     "tax_free": 0,
+	 *     "vat": 200,
+	 *     "point": 0,
+	 *     "discount": 0,
+	 *     "green_deposit": 0
+	 *   },
+	 *  "canceled_amount": {
+	 *         "total": 0,
+	 *         "tax_free": 0,
+	 *         "vat": 0,
+	 *         "point": 0,
+	 *         "discount": 0,
+	 *         "green_deposit": 0
+	 *  },
+	 *  "cancel_available_amount": {
+	 *         "total": 0,
+	 *         "tax_free": 0,
+	 *         "vat": 0,
+	 *         "point": 0,
+	 *         "discount": 0,
+	 *         "green_deposit": 0
+	 *  },
+	 *  "created_at": "2023-07-15T21:18:22",
+	 *  "approved_at": "2023-07-15T21:18:22",
+	 *  "payment_action_details": [
+	 *     {
+	 *             "aid": "A5678901234567890123",
+	 *             "payment_action_type": "PAYMENT",
+	 *             "payment_method_type": "MONEY",
+	 *             "amount": 2200,
+	 *             "point_amount": 0,
+	 *             "discount_amount": 0,
+	 *             "approved_at": "2023-07-15T21:18:22",
+	 *             "green_deposit": 0
+	 *     }
+	 *  ]
+	 * }
+	 */
+	String checkPayment();
+}

--- a/src/main/java/org/c4marathon/assignment/payment/client/kakao/dto/request/StartPaymentRequest.java
+++ b/src/main/java/org/c4marathon/assignment/payment/client/kakao/dto/request/StartPaymentRequest.java
@@ -1,0 +1,53 @@
+package org.c4marathon.assignment.payment.client.kakao.dto.request;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {
+ * "cid": "TC0ONETIME",
+ * "partner_order_id": "partner_order_id",
+ * "partner_user_id": "partner_user_id",
+ * "item_name": "초코파이",
+ * "quantity": "1",
+ * "total_amount": "2200",
+ * "vat_amount": "200",
+ * "tax_free_amount": "0",
+ * "approval_url": "https://developers.kakao.com/success",
+ * "fail_url": "https://developers.kakao.com/fail",
+ * "cancel_url": "https://developers.kakao.com/cancel"
+ * }
+ */
+public record StartPaymentRequest(
+	/* 가맹점 코드, 10자 */
+	String cid,
+	/* 가맹점 코드 인증키, 24자, 숫자와 영문 소문자 조합 */
+	String cidSecret,
+	String partnerOrderId, // 가맹점 주문번호, 최대 100자
+	String partnerUserId, // 가맹점 회원 id, 최대 100자 (실명, ID와 같은 개인정보가 포함되지 않도록 유의)
+	String itemName, // 상품명, 최대 100자
+	String itemCode, // 상품코드, 최대 100자
+	Integer quantity, // 상품 수량
+	Integer totalAmount, // 상품 총액
+	Integer taxFreeAmount, // 상품 비과세 금액
+	Integer vatAmount, // 상품 부가세 금액. 값을 보내지 않을 경우 다음과 같이 VAT 자동 계산 (상품총액 - 상품 비과세 금액)/11 : 소수점 이하 반올림
+	Integer greenDeposit, // 컵 보증금
+	String approvalUrl, // 결제 성공 시 redirect url, 최대 255자
+	String cancelUrl, // 결제 취소 시 redirect url, 최대 255자
+	String failUrl, // 결제 실패 시 redirect url, 최대 255자
+	List<String> availableCards,
+	// 결제 수단으로써 사용 허가할 카드사를 지정해야 하는 경우 사용. 카카오페이와 사전 협의 필요. 사용 허가할 카드사 코드*의 배열. ex) ["HANA", "BC"]. (기본값: 모든 카드사 허용)
+	String paymentMethodType, // 사용 허가할 결제 수단, 지정하지 않으면 모든 결제 수단 허용. CARD 또는 MONEY 중 하나
+	Integer installMonth, // 카드 할부개월, 0~12
+	String useShareInstallment, // 분담무이자 설정 (Y/N), 사용 시 사전 협의 필요
+	Map<String, String> customJson
+	// 사전에 정의된 기능. 1. 결제 화면에 보여줄 사용자 정의 문구, 카카오페이와 사전 협의 필요. 2. iOS에서 사용자 인증 완료 후 가맹점 앱으로 자동 전환 기능(iOS만 처리가능, 안드로이드 동작불가). ex) return_custom_url과 함께 key 정보에 앱스킴을 넣어서 전송. "return_custom_url":"kakaotalk://"
+) {
+	public static StartPaymentRequest of(String cid, String partnerOrderId, String partnerUserId,
+										 String itemName, Integer quantity, Integer totalAmount,
+										 Integer taxFreeAmount, String approvalUrl,
+										 String cancelUrl, String failUrl) {
+		return new StartPaymentRequest(cid, null, partnerOrderId, partnerUserId, itemName, null, quantity, totalAmount,
+			taxFreeAmount, null, null, approvalUrl, cancelUrl, failUrl, null, null, null, null, null);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/payment/client/kakao/dto/response/StartPaymentResponse.java
+++ b/src/main/java/org/c4marathon/assignment/payment/client/kakao/dto/response/StartPaymentResponse.java
@@ -1,0 +1,14 @@
+package org.c4marathon.assignment.payment.client.kakao.dto.response;
+
+import java.time.LocalDateTime;
+
+public record StartPaymentResponse(
+	String tid,
+	String next_redirect_app_url,
+	String next_redirect_mobile_url,
+	String next_redirect_pc_url,
+	String android_app_scheme,
+	String ios_app_scheme,
+	LocalDateTime created_at
+) {
+}

--- a/src/main/java/org/c4marathon/assignment/payment/client/naver/NaverPayClient.java
+++ b/src/main/java/org/c4marathon/assignment/payment/client/naver/NaverPayClient.java
@@ -1,0 +1,214 @@
+package org.c4marathon.assignment.payment.client.naver;
+
+import org.springframework.web.service.annotation.PostExchange;
+
+public interface NaverPayClient {
+	/**
+	 * <h3>단건결제 예약</h3>
+	 * <p>
+	 *     결제예약을 수행하고 결제예약 ID를 반환합니다.
+	 *     해당 결제예약 ID를 이용하여 결제창을 호출합니다.
+	 * </p>
+	 *
+	 * <h5>sample</h5>
+	 * POST /{파트너 ID}/naverpay/payments/v2/reserve
+	 * X-Naver-Client-Id:{발급된 client id}
+	 * X-Naver-Client-Secret:{발급된 client secret}
+	 * X-NaverPay-Chain-Id:{발급된 chain id}
+	 * X-NaverPay-Idempotency-Key: {API 멱등성 키}
+	 * {
+	 *     "modelVersion": "2",
+	 *     "merchantUserKey": "muserkey",
+	 *     "merchantPayKey": "mpaykey",
+	 *     "productName": "상품명",
+	 *     "productCount": 10,
+	 *     "totalPayAmount": 1000,
+	 *     "returnUrl": "{your-returnUrl}",
+	 *     "taxScopeAmount": 1000,
+	 *     "taxExScopeAmount": 0,
+	 *     "environmentDepositAmount": 0,
+	 *     "purchaserName": "구매자이름",
+	 *     "purchaserBirthday": "20000101",
+	 *     "productItems": [{
+	 *             "categoryType": "BOOK",
+	 *             "categoryId": "GENERAL",
+	 *             "uid": "107922211",
+	 *             "name": "한국사",
+	 *             "payReferrer": "NAVER_BOOK",
+	 *             "count": 10
+	 *     }, {
+	 *             "categoryType": "MUSIC",
+	 *             "categoryId": "CD",
+	 *             "uid": "299911002",
+	 *             "name": "Loves",
+	 *             "payReferrer": "NAVER_BOOK",
+	 *             "count": 10
+	 *     }]
+	 * }
+	 *
+	 * @return
+	 * {
+	 *    "code" : "Success",
+	 *    "message" : "detail message(optional)",
+	 *    "body" : {
+	 *        "reserveId" : ""
+	 *    }
+	 * }
+	 */
+	@PostExchange("/{파트너 ID}/naverpay/payments/v2/reserve")
+	String startPayment();
+
+	/**
+	 * <h3>결제 승인</h3>
+	 * <p></p>
+	 *
+	 * <h5>sample</h5>
+	 * POST /{파트너 ID}/naverpay/payments/v2.2/apply/payment
+	 * X-Naver-Client-Id:{발급된 client id}
+	 * X-Naver-Client-Secret:{발급된 client secret}
+	 * X-NaverPay-Chain-Id:{발급된 chain id}
+	 * X-NaverPay-Idempotency-Key: {API 멱등성 키}
+	 * paymentId={네이버페이가 발급한 결제 번호}
+	 *
+	 * @return
+	 *   {
+	 *       "code" : "Success",
+	 *       "message": "detail message(optional)",
+	 *       "body": {
+	 *           "paymentId": "20170201NP1043587746",
+	 *           "detail": {
+	 *                  "productName": "상품명",
+	 *                  "merchantId": "loginId",
+	 *                  "merchantName": "가맹점명",
+	 *                  "cardNo": "465887**********",
+	 *                  "admissionYmdt": "20170201151722",
+	 *                  "payHistId": "20170201NP1043587781",
+	 *                  "totalPayAmount": 1000,
+	 *                  "applyPayAmount": 1000,
+	 *                  "primaryPayAmount": 1000,
+	 *                  "npointPayAmount": 0,
+	 *                  "giftCardAmount": 0,
+	 *                  "discountPayAmount": 0,
+	 *                  "taxScopeAmount": 1000,
+	 *                  "taxExScopeAmount": 0,
+	 *                  "environmentDepositAmount": 0,
+	 *                  "primaryPayMeans": "CARD",
+	 *                  "merchantPayKey": "order-key",
+	 *                  "merchantUserKey": "jenie",
+	 *                  "cardCorpCode": "C0",
+	 *                  "paymentId": "20170201NP1043587746",
+	 *                  "admissionTypeCode": "01",
+	 *                  "settleExpectAmount": 971,
+	 *                  "payCommissionAmount": 29,
+	 *                  "admissionState": "SUCCESS",
+	 *                  "tradeConfirmYmdt": "20170201152510",
+	 *                  "cardAuthNo": "17545616",
+	 *                  "cardInstCount": 0,
+	 *                  "usedCardPoint": false,
+	 *                  "bankCorpCode": "",
+	 *                  "bankAccountNo": "",
+	 *                  "settleExpected": false,
+	 *                  "extraDeduction": false,
+	 *                  "useCfmYmdt" : "20180703",
+	 *                  "userIdentifier": "t1GLYqqJ05MnViYdR/GdMDpzdocRclgTL4mBLn0R1Ls="
+	 *           }
+	 *       }
+	 *   }
+	 */
+	String acceptPayment();
+
+	/**
+	 * <h3>결제 취소</h3>
+	 * <p></p>
+	 *
+	 * <h5>sample</h5>
+	 * POST /{파트너 ID}/naverpay/payments/v1/cancel
+	 * X-Naver-Client-Id:{발급된 client id}
+	 * X-Naver-Client-Secret:{발급된 client secret}
+	 * X-NaverPay-Chain-Id:{발급된 chain id}
+	 * X-NaverPay-Idempotency-Key: {API 멱등성 키}
+	 * paymentId={결제 완료 시 전달된 paymentId}
+	 * cancelAmount={취소금액}
+	 * cancelReason=testCancel
+	 * cancelRequester=2
+	 *
+	 * @return
+	 */
+	String cancelPayment();
+
+	/**
+	 * <h3>결제내역조회</h3>
+	 * <p></p>
+	 *
+	 * <h5>sample</h5>
+	 * GET/POST /{파트너 ID}/naverpay/payments/v2.2/list/history/{paymentId}
+	 * X-Naver-Client-Id:{발급된 client id}
+	 * X-Naver-Client-Secret:{발급된 client secret}
+	 * X-NaverPay-Chain-Id:{발급된 chain id}
+	 * {
+	 *     "pageNumber": 1,
+	 *     "rowsPerPage": 50
+	 * }
+	 *
+	 * @return
+	 * {
+	 *     "code" : "Success",
+	 *     "message": "detail message(optional)",
+	 *     "body": {
+	 *         "responseCount": 1,
+	 *         "totalCount": 1,
+	 *         "totalPageCount": 1,
+	 *         "currentPageNumber": 1,
+	 *         "list": [
+	 *             {
+	 *                 "cardAuthNo": "00000000",
+	 *                 "bankAccountNo": "",
+	 *                 "bankCorpCode": "",
+	 *                 "paymentId": "20170000NP1000229665",
+	 *                 "cardCorpCode": "C0",
+	 *                 "cardInstCount": 0,
+	 *                 "usedCardPoint": false,
+	 *                 "settleInfo": {
+	 *                     "primaryCommissionAmount": 30,
+	 *                     "npointCommissionAmount": 20,
+	 *                     "giftCardCommissionAmount": 0,
+	 *                     "discountCommissionAmount": 0,
+	 *                     "primarySettleAmount": 470,
+	 *                     "npointSettleAmount": 480,
+	 *                     "giftCardSettleAmount": 0,
+	 *                     "discountSettleAmount": 0,
+	 *                     "totalSettleAmount": 950,
+	 *                     "totalCommissionAmount": 50,
+	 *                     "settleCreated": true
+	 *                 },
+	 *                 "merchantName": "나의가맹점",
+	 *                 "productName": "나의상품",
+	 *                 "payHistId": "20170000NP1000229668",
+	 *                 "merchantId": "MID12345",
+	 *                 "admissionYmdt": "20170914163930",
+	 *                 "tradeConfirmYmdt": "20170915163956",
+	 *                 "totalPayAmount": 1000,
+	 *                 "applyPayAmount": 1000,
+	 *                 "merchantPayKey": "orderKey-91516397",
+	 *                 "merchantUserKey": "ID12345",
+	 *                 "admissionTypeCode": "01",
+	 *                 "primaryPayMeans": "CARD",
+	 *                 "admissionState": "SUCCESS",
+	 *                 "primaryPayAmount": 500,
+	 *                 "npointPayAmount": 500,
+	 *                 "giftCardPayAmount": 0,
+	 *                 "discountPayAmount": 0,
+	 *                 "taxScopeAmount": 1000,
+	 *                 "taxExScopeAmount": 0,
+	 *                 "environmentDepositAmount": 0,
+	 *                 "cardNo": "123456**********",
+	 *                 "extraDeduction": false,
+	 *                 "useCfmYmdt" : "20180703",
+	 *                 "merchantExtraParameter" : "testExtraParameter"
+	 *            }
+	 *        ]
+	 *     }
+	 * }
+	 */
+	String checkPayment();
+}

--- a/src/main/java/org/c4marathon/assignment/payment/client/toss/TossPaymentClient.java
+++ b/src/main/java/org/c4marathon/assignment/payment/client/toss/TossPaymentClient.java
@@ -1,0 +1,141 @@
+package org.c4marathon.assignment.payment.client.toss;
+
+import org.c4marathon.assignment.payment.client.PaymentGatewayClient;
+
+public interface TossPaymentClient extends PaymentGatewayClient {
+	/**
+	 * <h3>결제 생성하기</h3>
+	 * <p>결제 건을 생성합니다.</p>
+	 *
+	 * <h5>sample</h5>
+	 * POST /api/v2/payments
+	 * {
+	 * "orderNo":"1",                                           # 토스몰 고유의 주문번호 (필수)
+	 * "amount":25000,                                          # 결제 금액 (필수)
+	 * "amountTaxFree":0,                                       # 비과세 금액 (필수)
+	 * "productDesc":"토스티셔츠",                                # 상품 정보 (필수)
+	 * "apiKey":"sk_test_w5lNQylNqa5lNQe013Nq",                 # 상점의 API Key (필수)
+	 * "retUrl":"http://YOUR-SITE.COM/ORDER-CHECK?orderno=1",   # 결제 완료 후 연결할 웹 URL (필수)
+	 * "retCancelUrl":"http://YOUR-SITE.COM/close",             # 결제 취소 시 연결할 웹 URL (필수)
+	 * "autoExecute":true,                                      # 자동 승인 설정 (필수)
+	 * "resultCallback":"https://YOUR-SITE.COM/callback",       # 결제 결과 callback 웹 URL (필수-자동승인설정 true의 경우)
+	 * "callbackVersion":"V2",                                  # callback 버전 (필수-자동승인설정 true의 경우)
+	 * "amountTaxable":22727,                                   # 결제 금액 중 과세금액
+	 * "amountVat":2273,                                        # 결제 금액 중 부가세
+	 * "amountServiceFee":0,                                    # 결제 금액 중 봉사료
+	 * "expiredTime":"2019-06-17 12:47:35",                     # 결제 만료 예정 시각
+	 * "cashReceipt":true,                                      # 현금영수증 발급 가능 여부
+	 * }
+	 *
+	 * @return
+	 * {
+	 * "code":0,
+	 * "checkoutPage":"https://pay.toss.im/payfront/auth?payToken=test_token1234567890",
+	 * "payToken":"example-payToken"
+	 * }
+	 */
+	String startPayment();
+
+	/**
+	 * <h3>승인하기</h3>
+	 * <p>
+	 *     결제 처리가 완료되면 결제 상태가 변경되고, 토스는 가맹점 서버로 변경 사항을 알려드립니다.
+	 *     자동 승인 설정 시 (autoExecute가 true) 필수적으로 활용해야 합니다.
+	 *     생성된 결제 건에 resultCallback 파라미터 값이 있을 경우에만 동작합니다.
+	 * </p>
+	 *
+	 * POST YOUR-SITE.COM/callback (결제 생성 시 가맹점에서 설정한 callback URL)
+	 * {
+	 *  "status": "PAY_COMPLETE",
+	 *  "payToken": "example-payToken",
+	 *  "orderNo": "1",
+	 *  "payMethod": "CARD",
+	 *  "amount": 3000,
+	 *  "discountedAmount": 600,
+	 *  "paidAmount": 2300,
+	 *  "paidTs": "2020-04-03 14:22:37",
+	 *  "transactionId" : "dc3b951a-9781-462e-ab5a-b8a0bea0222a",
+	 *  "cardCompanyCode": 3,
+	 *  "cardAuthorizationNo": "87654321",
+	 *  "spreadOut": 0,
+	 *  "noInterest": false,
+	 *  "cardMethodType": "CREDIT",
+	 *  "cardUserType": "PERSONAL",
+	 *  "cardNumber": "654321******1234",
+	 *  "cardBinNumber": "654321",
+	 *  "cardNum4Print": "1234",
+	 *  "salesCheckLinkUrl": "https://pay.toss.im/payfront/web/external/sales-check?payToken=example-payToken&transactionId=2da1ca05-d91d-410f-976d-7a610242da8a",
+	 *  //"paidPoint": 0, // 2020.08.06 이후 fadeout 된 레거시 포인트 금액으로 0원으로 나감
+	 * }
+	 *
+	 * <p>
+	 *     결제완료 callback을 받았을 때, 결제완료 상태를 변경하시고 재고차감 등의 로직을 처리해 주세요.
+	 * </p>
+	 *
+	 * <h5>sample</h5>
+	 * POST /api/v2/execute
+	 * {
+	 * "apiKey":"sk_test_w5lNQylNqa5lNQe013Nq", # 상점의 API Key (필수)
+	 * "payToken":"example-payToken",           # 결제 고유 번호 (필수)
+	 * }
+	 *
+	 * @return
+	 * none
+	 */
+	String acceptPayment();
+
+	/**
+	 * <h3>환불하기</h3>
+	 *
+	 * <h5>sample</h5>
+	 * POST /api/v2/refunds
+	 * {
+	 * "apiKey":"sk_test_w5lNQylNqa5lNQe013Nq", # 상점의 API Key (필수)
+	 * "payToken":"example-payToken",           # 결제 고유 번호 (필수)
+	 * "amount":10000,                          # 환불할 금액 (필수)
+	 * "amountTaxable":5000,                    # 환불할 금액 중 과세금액
+	 * "amountTaxFree":4000,                    # 환불할 금액 중 비과세금액 (필수)
+	 * "amountVat":500,                         # 환불할 금액 중 부가세
+	 * "amountServiceFee":500                   # 환불할 금액 중 봉사료
+	 * }
+	 *
+	 * @return
+	 * none
+	 */
+	String cancelPayment();
+
+	/**
+	 * <h3>결제 상태 알아보기</h3>
+	 *
+	 * <h5>sample</h5>
+	 * POST /api/v2/status
+	 * {
+	 * "apiKey":"sk_test_w5lNQylNqa5lNQe013Nq",   # 상점의 API Key (필수)
+	 * "payToken":"example-payToken",             # 결제 고유 번호 (필수)
+	 * }
+	 *
+	 * @return
+	 * {
+	 * "code": 0,                            # 응답코드
+	 * "payToken": "example-payToken",       # 결제 고유 토큰
+	 * "orderNo": "1",                       # 상점의 주문번호
+	 * "payStatus": "PAY_COMPLETE",          # 결제 상태
+	 * "payMethod": "TOSS_MONEY",            # 결제 수단
+	 * "amount": 15000,                      # 결제 요청금액
+	 * "transactions": [                     # 거래 트랜잭션 목록
+	 *  {
+	 *     "stepType": "PAY",
+	 *     "transactionId": "3243c76e-4669-881b-33a3b82ddf49",
+	 *     "transactionAmount": 15000,
+	 *     "discountAmount": 300,
+	 *     "pointAmount": 0,
+	 *     "paidAmount": 14700,
+	 *     "regTs": "2020-03-01 12:33:20"
+	 *   }
+	 * ],
+	 * "createdTs": "2020-03-01 12:33:04",   # 최초 결제요청 시간
+	 * "paidTs": "2020-03-01 12:33:20"       # 결제 완료 처리 시간
+	 * }
+	 */
+	String checkPayment();
+}


### PR DESCRIPTION
## ✨ 신규 앤드포인트.

|method|path|설명|
|---|---|---|
|POST|/customers/my/charge-point|포인트 충전|
|POST|/products/{id}/order|신규 주문|
|POST|/payment/{PaymentGateway}/ready|결제 생성|
|POST|/payment/{PaymentGateway}/call-back|결제 콜백|
|POST|/payment/{PaymentGateway}/grant|결제 승락|


## 💡 이런 고민을 했어요.

### 1. "결제"가 담당하는 역할과 그 범위

포인트 충전, 주문 등 결제가 필요한 서비스를 보완해주는 `supporting domain`

#### EDA

결제 서비스와 다른 서비스 사이의 강결합을 끊어내기 위해 Event 도입

#### 플로우

사용자가 유료 서비스(ex. 포인트 충전, 주문)을 호출
-> Payment 레코드(NOT_STARTED) 저장 및 check-out page로 리다이렉트
-> 사용자가 결제 인증에 성공하면 자사의 결제 승인 Api 호출
-> Payment 레코드(EXECUTING) -> PG사의 결제 승인 Api 호출 -> Payment 레코드(SUCCESS/FAILURE/UNKNOWN) + PaymentEvent 레코드
-> `Payment Confirm Event` 발행

EventListener는 Payment Confirm Event 발행을 인지
-> 포인트 충전 결제: 사용자의 포인트 충전(WalletService)
-> 주문 결제: 주문 생성(OrderService)


### 2. 자체 포인트와 외부 PG 연동

외부 PG사를 통해서 결제를 진행하게 되면 수수료가 발생한다.
자체 Pay를 사용할 때는 이런 수수료를 절감하기 위해 금융결제원의 오픈뱅킹을 사용하면 좋을 것 같은데, 이용적합성 승인을 요구하기 때문에 도입하기 어렵다.

#### 결론 : Toss Payment만 연동하여 구현


### 3. 결제 api 호출과 트랜잭션

Transactional Outbox Pattern

#### 결론 : 


## 📑 다음 자료를 참고하면 좋아요.

- [금융결제원(오픈뱅킹)](https://developers.kftc.or.kr/dev)
- [토스페이](https://tossdev.github.io/index.html)
- [카카오페이](https://developers.kakaopay.com/docs/payment/online/common)
- [네이버페이](https://developers.pay.naver.com/)


## ✅ 셀프 체크리스트

- [ ] 내 코드를 스스로 검토했습니다.
- [ ] 필요한 테스트를 추가했습니다.
- [ ] 모든 테스트를 통과합니다.
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [ ] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] wiki를 수정했습니다.
